### PR TITLE
fix: call useEditorIsActive argument if it's a function

### DIFF
--- a/packages/solid-tiptap/src/Editor.tsx
+++ b/packages/solid-tiptap/src/Editor.tsx
@@ -91,6 +91,9 @@ export function useEditorIsActive<V extends Editor | undefined, R extends Record
         args[1],
       );
     }
+    if (typeof args[0] === "function") {
+      return instance?.isActive(args[0]());
+    }
     return instance?.isActive(
       args[0],
     );


### PR DESCRIPTION
The bug: In the below situation the function (2nd argument) won't be called:
```typescript
const isBold = useEditorIsActive(
    () => props.editor,
    () => "bold",
);
```
Btw why It's a function? Is it related to Reactivity?