### PR TITLE
refactor: simplify forcing update

### DIFF
--- a/packages/solid-tiptap/src/Editor.tsx
+++ b/packages/solid-tiptap/src/Editor.tsx
@@ -20,10 +20,10 @@ export function createEditorTransaction<T, V extends Editor | undefined>(
   instance: () => V,
   read: (value: V) => T,
 ): () => T {
-  const [depend, rerun] = createSignal(undefined, { equals: false });
+  const [depend, update] = createSignal(undefined, { equals: false });
 
   function forceUpdate() {
-    rerun()
+    update()
   }
 
   createEffect(() => {

--- a/packages/solid-tiptap/src/Editor.tsx
+++ b/packages/solid-tiptap/src/Editor.tsx
@@ -20,24 +20,20 @@ export function createEditorTransaction<T, V extends Editor | undefined>(
   instance: () => V,
   read: (value: V) => T,
 ): () => T {
-  const [signal, setSignal] = createSignal([]);
-
-  function forceUpdate() {
-    setSignal([]);
-  }
+  const [depend, rerun] = createSignal(undefined, { equals: false });
 
   createEffect(() => {
     const editor = instance();
     if (editor) {
-      editor.on('transaction', forceUpdate);
+      editor.on('transaction', rerun);
       onCleanup(() => {
-        editor.off('transaction', forceUpdate);
+        editor.off('transaction', rerun);
       });
     }
   });
 
   return () => {
-    signal();
+    depend();
     return read(instance());
   };
 }

--- a/packages/solid-tiptap/src/Editor.tsx
+++ b/packages/solid-tiptap/src/Editor.tsx
@@ -22,12 +22,16 @@ export function createEditorTransaction<T, V extends Editor | undefined>(
 ): () => T {
   const [depend, rerun] = createSignal(undefined, { equals: false });
 
+  function forceUpdate() {
+    rerun()
+  }
+
   createEffect(() => {
     const editor = instance();
     if (editor) {
-      editor.on('transaction', rerun);
+      editor.on('transaction', forceUpdate);
       onCleanup(() => {
-        editor.off('transaction', rerun);
+        editor.off('transaction', forceUpdate);
       });
     }
   });


### PR DESCRIPTION
I'm not exactly sure if it's any better in terms of performance but I think this is a simpler approach. It has two benefits that I can think of:

1. It doesn't create a new array every time a transaction happens.
2. Equality check is not needed: Every time `setSignal` gets called, Solid runs `oldValue === newValue` to check if the value is actually changed. With this approach this check is not needed.

https://www.solidjs.com/docs/latest/api#options