### PR TITLE
fix: remove unnecessary cloning of the editor options

### DIFF
--- a/packages/solid-tiptap/src/Editor.tsx
+++ b/packages/solid-tiptap/src/Editor.tsx
@@ -48,9 +48,7 @@ export default function useEditor<T extends HTMLElement>(
   const [signal, setSignal] = createSignal<Editor>();
 
   createEffect(() => {
-    const instance = new Editor({
-      ...props(),
-    });
+    const instance = new Editor(props());
 
     onCleanup(() => {
       instance.destroy();


### PR DESCRIPTION
Can't think of any reason to copy the edition options here.