### PR TITLE
fix!: remove useCharacterCount

### DIFF
--- a/packages/solid-tiptap/src/Editor.tsx
+++ b/packages/solid-tiptap/src/Editor.tsx
@@ -70,12 +70,6 @@ export function useEditorJSON<V extends Editor | undefined, R extends Record<str
   return createEditorTransaction(editor, (instance) => instance?.getJSON() as R);
 }
 
-export function useEditorCharacterCount<V extends Editor | undefined>(
-  editor: () => V,
-): () => number | undefined {
-  return createEditorTransaction(editor, (instance) => instance?.getCharacterCount());
-}
-
 export function useEditorIsActive<V extends Editor | undefined, R extends Record<string, any>>(
   editor: () => V,
   ...args: [name: () => string, options?: R] | [options: R]


### PR DESCRIPTION
THIS IS A BREAKING CHANGE. DO NOT MERGE IT UNTIL YOU WANT TO DO A MAJOR RELEASE.

The `getCharacterCount` function is deprecated and its functionality is moved to a separate extension. 

closes: https://github.com/lxsmnsyc/solid-tiptap/issues/6 